### PR TITLE
Tab 2: Fix issue when only 2 years are selected

### DIFF
--- a/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/no_suicide_app.py
+++ b/no_suicide_app.py
@@ -405,7 +405,7 @@ def make_plot2a(country_a = 'Any Country', country_b = 'Any Country', year_list 
     b = country_b
 
     # Makes DataFrame of average suicide rates for the 2 countries
-    data2a = final_df.query('suicides_per_100k_pop>0.1').query('year > @year_start & year < @year_end').query('country == @a | country == @b').groupby(['country']).agg({'suicides_per_100k_pop':'mean'})
+    data2a = final_df.query('suicides_per_100k_pop>0.1').query('year >= @year_start & year <= @year_end').query('country == @a | country == @b').groupby(['country']).agg({'suicides_per_100k_pop':'mean'})
     data2a = data2a.reset_index()
 
     # Rounds values to 2 decimal points


### PR DESCRIPTION
Ellen pointed out in the Milestone 2 feedback that the charts don't update when only 2 years are selected. This update fixes this issue.